### PR TITLE
Feature/mikki 140 선상낚시 게시글 및 상세페이지 구현

### DIFF
--- a/src/app/api/boatPostMock/[id]/route.ts
+++ b/src/app/api/boatPostMock/[id]/route.ts
@@ -1,0 +1,48 @@
+import { PostDetailType } from "@/types/boatPostType";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const dummyApiResponse: PostDetailType = {
+    timestamp: "2025-04-07T15:32:34.893934441Z",
+    data: {
+      detailShipFishingPost: {
+        shipFishingPostId: 1,
+        subject: "빵빵이호 낚시 투어",
+        content:
+          "동해안 최고의 우럭 포인트에서 낚시를 즐겨보세요! 초보자도 쉽게 잡을 수 있는 포인트로 안내해 드립니다. \n낚시 장비는 모두 제공되며, 잡은 물고기는 손질해서 가져가실 수 있습니다. \n선상에서 간단한 식사와 음료가 제공됩니다. 가족, 친구들과 함께 잊지 못할 낚시 경험을 만들어보세요.",
+        price: 100000,
+        imageList: [
+          "/placeholder.svg?height=200&width=300",
+          "/placeholder.svg?height=200&width=300",
+        ],
+        startTime: "15:00",
+        durationTime: "02:30",
+        maxGuestCount: 10,
+        reviewEverRate: 5.0,
+      },
+      detailShip: {
+        shipId: 1,
+        shipName: "빵빵이호",
+        shipNumber: "SEA123",
+        departurePort: "부산 기장군 기장읍 연화리 어촌계 선착장",
+        publicRestroom: true,
+        loungeArea: true,
+        kitchenFacility: true,
+        fishingChair: true,
+        passengerInsurance: true,
+        fishingGearRental: true,
+        mealProvided: true,
+        parkingAvailable: true,
+      },
+      detailMember: {
+        memberId: 1,
+        email: "captain@example.com",
+        name: "김선장",
+        phone: "010-1234-5678",
+      },
+    },
+    success: true,
+  };
+
+  return NextResponse.json(dummyApiResponse);
+}

--- a/src/app/api/boatPostMock/[id]/route.ts
+++ b/src/app/api/boatPostMock/[id]/route.ts
@@ -25,7 +25,7 @@ export async function GET() {
         shipName: "빵빵이호",
         shipNumber: "SEA123",
         departurePort: "부산 기장군 기장읍 연화리 어촌계 선착장",
-        publicRestroom: true,
+        publicRestroom: true, //공용 화장실, 남/여 구분 화장실, 없음
         loungeArea: true,
         kitchenFacility: true,
         fishingChair: true,

--- a/src/app/api/boatPostMock/route.ts
+++ b/src/app/api/boatPostMock/route.ts
@@ -1,0 +1,73 @@
+import { PostType } from "@/types/boatPostType";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  // 더미 데이터
+  const dummyBoats: PostType[] = [
+    {
+      subject: "빵빵이호 낚시 투어",
+      price: 80000,
+      location: "부산 기장군",
+      startTime: "15:00",
+      endTime: "17:30",
+      durationTime: "02:30",
+      shipFishingPostId: 1,
+      imageList: [
+        "/placeholder.svg?height=200&width=300",
+        "/placeholder.svg?height=200&width=300",
+      ],
+      fishList: [1, 2, 3],
+      reviewEverRate: 5.0,
+      reviewCount: 31,
+    },
+    {
+      subject: "옥지호 바다 낚시",
+      price: 120000,
+      location: "제주 서귀포시",
+      startTime: "09:00",
+      endTime: "12:00",
+      durationTime: "03:00",
+      shipFishingPostId: 2,
+      imageList: [
+        "/placeholder.svg?height=200&width=300",
+        "/placeholder.svg?height=200&width=300",
+      ],
+      fishList: [2, 4, 5],
+      reviewEverRate: 4.0,
+      reviewCount: 36,
+    },
+    {
+      subject: "김노엠호 낚시 투어",
+      price: 60000,
+      location: "인천 옹진군",
+      startTime: "13:00",
+      endTime: "16:00",
+      durationTime: "03:00",
+      shipFishingPostId: 3,
+      imageList: [
+        "/placeholder.svg?height=200&width=300",
+        "/placeholder.svg?height=200&width=300",
+      ],
+      fishList: [1, 3, 6],
+      reviewEverRate: 4.5,
+      reviewCount: 14,
+    },
+    {
+      subject: "제갈제니호 낚시",
+      price: 100000,
+      location: "강원 속초시",
+      startTime: "10:00",
+      endTime: "14:00",
+      durationTime: "04:00",
+      shipFishingPostId: 4,
+      imageList: [
+        "/placeholder.svg?height=200&width=300",
+        "/placeholder.svg?height=200&width=300",
+      ],
+      fishList: [2, 5, 7],
+      reviewEverRate: 2.5,
+      reviewCount: 32,
+    },
+  ];
+  return NextResponse.json(dummyBoats);
+}

--- a/src/app/api/boatPostMock/route.ts
+++ b/src/app/api/boatPostMock/route.ts
@@ -1,73 +1,80 @@
 import { PostType } from "@/types/boatPostType";
 import { NextResponse } from "next/server";
 
+const dummyBoats: PostType[] = [
+  {
+    subject: "빵빵이호 낚시 투어",
+    price: 80000,
+    location: "부산 기장군",
+    startTime: "15:00",
+    endTime: "17:30",
+    durationTime: "02:30",
+    shipFishingPostId: 1,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [1, 2, 3],
+    reviewEverRate: 5.0,
+    reviewCount: 31,
+  },
+  {
+    subject: "옥지호 바다 낚시",
+    price: 120000,
+    location: "제주 서귀포시",
+    startTime: "09:00",
+    endTime: "12:00",
+    durationTime: "03:00",
+    shipFishingPostId: 2,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [2, 4, 5],
+    reviewEverRate: 4.0,
+    reviewCount: 36,
+  },
+  {
+    subject: "김노엠호 낚시 투어",
+    price: 60000,
+    location: "인천 옹진군",
+    startTime: "13:00",
+    endTime: "16:00",
+    durationTime: "03:00",
+    shipFishingPostId: 3,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [1, 3, 6],
+    reviewEverRate: 4.5,
+    reviewCount: 14,
+  },
+  {
+    subject: "제갈제니호 낚시",
+    price: 100000,
+    location: "강원 속초시",
+    startTime: "10:00",
+    endTime: "14:00",
+    durationTime: "04:00",
+    shipFishingPostId: 4,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [2, 5, 7],
+    reviewEverRate: 2.5,
+    reviewCount: 32,
+  },
+];
+
 export async function GET() {
-  // 더미 데이터
-  const dummyBoats: PostType[] = [
-    {
-      subject: "빵빵이호 낚시 투어",
-      price: 80000,
-      location: "부산 기장군",
-      startTime: "15:00",
-      endTime: "17:30",
-      durationTime: "02:30",
-      shipFishingPostId: 1,
-      imageList: [
-        "/placeholder.svg?height=200&width=300",
-        "/placeholder.svg?height=200&width=300",
-      ],
-      fishList: [1, 2, 3],
-      reviewEverRate: 5.0,
-      reviewCount: 31,
-    },
-    {
-      subject: "옥지호 바다 낚시",
-      price: 120000,
-      location: "제주 서귀포시",
-      startTime: "09:00",
-      endTime: "12:00",
-      durationTime: "03:00",
-      shipFishingPostId: 2,
-      imageList: [
-        "/placeholder.svg?height=200&width=300",
-        "/placeholder.svg?height=200&width=300",
-      ],
-      fishList: [2, 4, 5],
-      reviewEverRate: 4.0,
-      reviewCount: 36,
-    },
-    {
-      subject: "김노엠호 낚시 투어",
-      price: 60000,
-      location: "인천 옹진군",
-      startTime: "13:00",
-      endTime: "16:00",
-      durationTime: "03:00",
-      shipFishingPostId: 3,
-      imageList: [
-        "/placeholder.svg?height=200&width=300",
-        "/placeholder.svg?height=200&width=300",
-      ],
-      fishList: [1, 3, 6],
-      reviewEverRate: 4.5,
-      reviewCount: 14,
-    },
-    {
-      subject: "제갈제니호 낚시",
-      price: 100000,
-      location: "강원 속초시",
-      startTime: "10:00",
-      endTime: "14:00",
-      durationTime: "04:00",
-      shipFishingPostId: 4,
-      imageList: [
-        "/placeholder.svg?height=200&width=300",
-        "/placeholder.svg?height=200&width=300",
-      ],
-      fishList: [2, 5, 7],
-      reviewEverRate: 2.5,
-      reviewCount: 32,
-    },
-  ];
   return NextResponse.json(dummyBoats);
+}
+
+export async function POST(req: Request) {
+  const newPost: PostType = await req.json();
+  newPost.shipFishingPostId = dummyBoats.length + 1;
+  dummyBoats.push(newPost);
+  return NextResponse.json(newPost);
 }

--- a/src/app/boat-reservation/[id]/components/ImageGallery.tsx
+++ b/src/app/boat-reservation/[id]/components/ImageGallery.tsx
@@ -1,18 +1,22 @@
-import Image from "next/image";
-import {Button} from "@/components/ui/button";
-import {ChevronLeft, ChevronRight} from "lucide-react";
-import React, {useState} from "react";
+"use client";
 
-export default function ImageGallery(){
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import React, { useState } from "react";
+
+export default function ImageGallery() {
   // 이미지 갤러리 네비게이션
   const nextImage = () => {
-    setCurrentImageIndex((prevIndex) => (prevIndex + 1) % images.length)
-  }
+    setCurrentImageIndex((prevIndex) => (prevIndex + 1) % images.length);
+  };
 
   const prevImage = () => {
-    setCurrentImageIndex((prevIndex) => (prevIndex - 1 + images.length) % images.length)
-  }
-  const [currentImageIndex, setCurrentImageIndex] = useState(0)
+    setCurrentImageIndex(
+      (prevIndex) => (prevIndex - 1 + images.length) % images.length
+    );
+  };
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
   // 이미지 갤러리 데이터
   const images = [
@@ -20,7 +24,7 @@ export default function ImageGallery(){
     "/placeholder.svg?height=500&width=800",
     "/placeholder.svg?height=500&width=800",
     "/placeholder.svg?height=500&width=800",
-  ]
+  ];
   return (
     <>
       {/* 이미지 갤러리 */}
@@ -54,7 +58,9 @@ export default function ImageGallery(){
           {images.map((_, index) => (
             <button
               key={index}
-              className={`w-2 h-2 rounded-full cursor-pointer ${index === currentImageIndex ? "bg-white" : "bg-white/50"}`}
+              className={`w-2 h-2 rounded-full cursor-pointer ${
+                index === currentImageIndex ? "bg-white" : "bg-white/50"
+              }`}
               onClick={() => setCurrentImageIndex(index)}
             />
           ))}
@@ -82,5 +88,5 @@ export default function ImageGallery(){
         ))}
       </div>
     </>
-  )
+  );
 }

--- a/src/app/boat-reservation/[id]/components/PlaceInfo.tsx
+++ b/src/app/boat-reservation/[id]/components/PlaceInfo.tsx
@@ -1,6 +1,6 @@
-import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type React from "react";
-import {Car} from "lucide-react";
+import { Car } from "lucide-react";
 
 export default function PlaceInfo() {
   return (
@@ -12,14 +12,16 @@ export default function PlaceInfo() {
         <div className="bg-gray-200 rounded-lg h-48 flex items-center justify-center">
           <p className="text-gray-500">지도 이미지</p>
         </div>
-        <p className="text-gray-700">부산광역시 기장군 기장읍 연화리 어촌계 선착장</p>
+        <p className="text-gray-700">
+          부산광역시 기장군 기장읍 연화리 어촌계 선착장
+        </p>
         <div className="text-sm text-gray-600 space-y-2">
           <div className="flex items-start">
-            <Car size={18} className="mr-2"/>
+            <Car size={18} className="mr-2" />
             <span>주차: 무료 주차장 이용 가능</span>
           </div>
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/app/boat-reservation/[id]/components/ReservationInfo.tsx
+++ b/src/app/boat-reservation/[id]/components/ReservationInfo.tsx
@@ -1,21 +1,40 @@
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
-import {CalendarIcon, MapPin, Star} from "lucide-react";
-import {Separator} from "@/components/ui/separator";
-import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover";
-import {Button} from "@/components/ui/button";
-import {format} from "date-fns";
-import {ko} from "date-fns/locale";
-import {Calendar} from "@/components/ui/calendar";
-import React, {useState} from "react";
+"use client";
 
-export default function ReservationInfo(){
-  const [date, setDate] = useState<Date | undefined>(undefined)
-  const [selectedPeople, setSelectedPeople] = useState(1)
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CalendarIcon, MapPin, Star } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import { Calendar } from "@/components/ui/calendar";
+import React, { useState } from "react";
+import { PostDetailPost } from "@/types/boatPostType";
+
+export default function ReservationInfo({
+  detailShipFishingPost,
+}: {
+  detailShipFishingPost: PostDetailPost;
+}) {
+  const [date, setDate] = useState<Date | undefined>(undefined);
+  const [selectedPeople, setSelectedPeople] = useState(1);
 
   return (
     <Card className="shadow-lg">
       <CardHeader>
-        <CardTitle className="text-2xl">해양호</CardTitle>
+        <CardTitle className="text-2xl">
+          {detailShipFishingPost.subject}
+        </CardTitle>
         <CardDescription className="flex items-center">
           <MapPin className="h-4 w-4 mr-1" /> 부산 기장군
         </CardDescription>
@@ -35,13 +54,24 @@ export default function ReservationInfo(){
           <h3 className="font-medium mb-3">날짜 선택</h3>
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full cursor-pointer justify-start text-left font-normal">
+              <Button
+                variant="outline"
+                className="w-full cursor-pointer justify-start text-left font-normal"
+              >
                 <CalendarIcon className="mr-2 h-4 w-4" />
-                {date ? format(date, "PPP", { locale: ko }) : "날짜를 선택하세요"}
+                {date
+                  ? format(date, "PPP", { locale: ko })
+                  : "날짜를 선택하세요"}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0">
-              <Calendar mode="single" selected={date} onSelect={setDate} initialFocus locale={ko} />
+              <Calendar
+                mode="single"
+                selected={date}
+                onSelect={setDate}
+                initialFocus
+                locale={ko}
+              />
             </PopoverContent>
           </Popover>
         </div>
@@ -62,7 +92,9 @@ export default function ReservationInfo(){
               variant="outline"
               size="icon"
               className="cursor-pointer"
-              onClick={() => setSelectedPeople(Math.min(10, selectedPeople + 1))}
+              onClick={() =>
+                setSelectedPeople(Math.min(10, selectedPeople + 1))
+              }
             >
               +
             </Button>
@@ -74,22 +106,25 @@ export default function ReservationInfo(){
         <div className="space-y-2">
           <div className="flex justify-between">
             <span>기본 요금 (1인)</span>
-            <span>₩80,000</span>
+            <span>₩{detailShipFishingPost.price}</span>
           </div>
           {selectedPeople > 1 && (
             <div className="flex justify-between text-gray-600">
               <span>추가 인원 ({selectedPeople - 1}명)</span>
-              <span>₩{(selectedPeople - 1) * 80000}</span>
+              <span>₩{(selectedPeople - 1) * detailShipFishingPost.price}</span>
             </div>
           )}
           <Separator />
           <div className="flex justify-between font-bold text-lg">
             <span>총 금액</span>
-            <span>₩{selectedPeople * 80000}</span>
+            <span>₩{selectedPeople * detailShipFishingPost.price}</span>
           </div>
         </div>
 
-        <Button className="w-full bg-primary hover:bg-cyan-700 text-lg py-6" disabled={!date}>
+        <Button
+          className="w-full bg-primary hover:bg-cyan-700 text-lg py-6"
+          disabled={!date}
+        >
           {date ? "예약하기" : "날짜를 선택해주세요"}
         </Button>
 
@@ -98,5 +133,5 @@ export default function ReservationInfo(){
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/app/boat-reservation/[id]/components/TabDetail.tsx
+++ b/src/app/boat-reservation/[id]/components/TabDetail.tsx
@@ -1,16 +1,77 @@
-import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
-import {Anchor, Clock, Droplets, MapPin, Ship, Users, Utensils, Wifi} from "lucide-react";
-import {Separator} from "@/components/ui/separator";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Anchor,
+  Clock,
+  Droplets,
+  MapPin,
+  Ship,
+  Users,
+  Utensils,
+  Shield,
+  Fish,
+  Car,
+} from "lucide-react";
+import { Separator } from "@/components/ui/separator";
 import type React from "react";
+import { PostDetailPost, PostDetailShip } from "@/types/boatPostType";
 
-export default function TabDetail(){
+export default function TabDetail({
+  detailShipFishingPost,
+  detailShip,
+}: {
+  detailShipFishingPost: PostDetailPost;
+  detailShip: PostDetailShip;
+}) {
   // 편의시설 정보
-  const amenities = [
-    { icon: <Ship className="h-5 w-5" />, name: "선실", description: "쾌적한 실내 공간" },
-    { icon: <Utensils className="h-5 w-5" />, name: "식사 제공", description: "점심 도시락 포함" },
-    { icon: <Droplets className="h-5 w-5" />, name: "화장실", description: "깨끗한 화장실 구비" },
-    { icon: <Wifi className="h-5 w-5" />, name: "와이파이", description: "무료 인터넷 제공" },
-  ]
+  const amenityConfig = {
+    publicRestroom: {
+      icon: <Droplets className="h-5 w-5" />,
+      name: "화장실",
+      description: "깨끗한 화장실 구비",
+    },
+    loungeArea: {
+      icon: <Ship className="h-5 w-5" />,
+      name: "휴게실",
+      description: "쾌적한 실내 공간",
+    },
+    kitchenFacility: {
+      icon: <Utensils className="h-5 w-5" />,
+      name: "주방 시설",
+      description: "간단한 조리 가능",
+    },
+    fishingChair: {
+      icon: <Anchor className="h-5 w-5" />,
+      name: "낚시 의자",
+      description: "편안한 낚시 의자 제공",
+    },
+    passengerInsurance: {
+      icon: <Shield className="h-5 w-5" />,
+      name: "여행자 보험",
+      description: "안전한 여행 보장",
+    },
+    fishingGearRental: {
+      icon: <Fish className="h-5 w-5" />,
+      name: "낚시 장비 대여",
+      description: "장비 대여 가능",
+    },
+    mealProvided: {
+      icon: <Utensils className="h-5 w-5" />,
+      name: "식사 제공",
+      description: "점심 도시락 포함",
+    },
+    parkingAvailable: {
+      icon: <Car className="h-5 w-5" />,
+      name: "주차 가능",
+      description: "무료 주차 제공",
+    },
+  };
+
+  const availableAmenities = Object.entries(detailShip)
+    .filter(
+      ([key, value]) =>
+        amenityConfig[key as keyof typeof amenityConfig] && value === true
+    )
+    .map(([key]) => amenityConfig[key as keyof typeof amenityConfig]);
 
   return (
     <Card>
@@ -25,28 +86,38 @@ export default function TabDetail(){
               <MapPin className="h-5 w-5 text-gray-500 mr-2 mt-0.5" />
               <div>
                 <p className="font-medium">출항지</p>
-                <p className="text-gray-600">부산 기장군 기장읍 연화리 어촌계 선착장</p>
+                <p className="text-gray-600">{detailShip.departurePort}</p>
               </div>
             </div>
             <div className="flex items-start">
               <Clock className="h-5 w-5 text-gray-500 mr-2 mt-0.5" />
               <div>
-                <p className="font-medium">출항 시간</p>
-                <p className="text-gray-600">오전 6시 (새벽 5시 30분까지 집결)</p>
+                <p className="font-medium">출-입항 시간</p>
+                <p className="text-gray-600">
+                  출항: {detailShipFishingPost.startTime}
+                </p>
+                <p className="text-gray-600">
+                  입항: {detailShipFishingPost.durationTime}
+                </p>
               </div>
             </div>
             <div className="flex items-start">
               <Anchor className="h-5 w-5 text-gray-500 mr-2 mt-0.5" />
               <div>
                 <p className="font-medium">선박 정보</p>
-                <p className="text-gray-600">해양호 (9.77톤, 정원 20명)</p>
+                <p className="text-gray-600">
+                  {detailShip.shipName} (정원{" "}
+                  {detailShipFishingPost.maxGuestCount}명)
+                </p>
               </div>
             </div>
             <div className="flex items-start">
               <Users className="h-5 w-5 text-gray-500 mr-2 mt-0.5" />
               <div>
                 <p className="font-medium">최소 인원</p>
-                <p className="text-gray-600">10명 (미달 시 출항 취소될 수 있음)</p>
+                <p className="text-gray-600">
+                  10명 (미달 시 출항 취소될 수 있음)
+                </p>
               </div>
             </div>
           </div>
@@ -56,26 +127,22 @@ export default function TabDetail(){
 
         <div>
           <h3 className="font-medium mb-2">낚시 정보</h3>
-          <p className="text-gray-700 mb-4">
-            기장 앞바다는 다양한 어종이 서식하는 천혜의 낚시터입니다. 특히 봄부터 가을까지는 참돔, 감성돔 등
-            고급 어종을 낚을 수 있는 최적의 장소입니다. 선장님의 30년 경력을 바탕으로 그날의 조황에 맞는
-            최적의 포인트로 안내해 드립니다.
-          </p>
-          <p className="text-gray-700">
-            초보자도 쉽게 낚시를 즐길 수 있도록 기본적인 낚시 방법을 알려드리며, 필요한 장비도 대여해
-            드립니다. 가족, 친구, 회사 동료들과 함께 잊지 못할 낚시 경험을 만들어 보세요.
-          </p>
+          <p className="text-gray-700">{detailShipFishingPost.content}</p>
         </div>
 
         <Separator />
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {amenities.map((amenity, index) => (
+          {availableAmenities.map((amenity, index) => (
             <div key={index} className="flex items-start space-x-4">
-              <div className="bg-sub-2 text-primary p-3 rounded-full">{amenity.icon}</div>
+              <div className="bg-sub-2 text-primary p-3 rounded-full">
+                {amenity.icon}
+              </div>
               <div>
                 <h4 className="font-medium">{amenity.name}</h4>
-                <p className="text-gray-600 text-sm mt-1">{amenity.description}</p>
+                <p className="text-gray-600 text-sm mt-1">
+                  {amenity.description}
+                </p>
               </div>
             </div>
           ))}
@@ -96,5 +163,5 @@ export default function TabDetail(){
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/app/boat-reservation/[id]/components/TabWater.tsx
+++ b/src/app/boat-reservation/[id]/components/TabWater.tsx
@@ -1,10 +1,18 @@
-import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
-import {ChevronLeft, ChevronRight, Droplets, Moon, Sun} from "lucide-react";
-import {Button} from "@/components/ui/button";
-import React, {useState} from "react";
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ChevronLeft, ChevronRight, Droplets, Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import React, { useState } from "react";
 
 export default function TabWater() {
-  const [currentTideIndex, setCurrentTideIndex] = useState(0)
+  const [currentTideIndex, setCurrentTideIndex] = useState(0);
 
   // 물때 정보
   const tideInfo = [
@@ -43,7 +51,7 @@ export default function TabWater() {
       highTide: ["12:15", "--:--"],
       lowTide: ["06:20", "18:50"],
     },
-  ]
+  ];
 
   return (
     <Card>
@@ -86,7 +94,10 @@ export default function TabWater() {
                       <div className="relative h-40 bg-gradient-to-b from-sky-50 to-blue-100 rounded-lg overflow-hidden">
                         {/* Tide Wave Visualization */}
                         <div className="absolute inset-0">
-                          <svg viewBox="0 0 1440 120" className="absolute bottom-0 w-full">
+                          <svg
+                            viewBox="0 0 1440 120"
+                            className="absolute bottom-0 w-full"
+                          >
                             <path
                               fill="rgba(59, 130, 246, 0.3)"
                               d="M0,64L48,80C96,96,192,128,288,128C384,128,480,96,576,85.3C672,75,768,85,864,96C960,107,1056,117,1152,112C1248,107,1344,85,1392,74.7L1440,64L1440,120L1392,120C1344,120,1248,120,1152,120C1056,120,960,120,864,120C768,120,672,120,576,120C480,120,384,120,288,120C192,120,96,120,48,120L0,120Z"
@@ -99,9 +110,10 @@ export default function TabWater() {
                           .filter((time) => time !== "--:--")
                           .map((time, i) => {
                             // Calculate position based on time (simplified)
-                            const hour = Number.parseInt(time.split(":")[0])
-                            const minute = Number.parseInt(time.split(":")[1])
-                            const position = ((hour * 60 + minute) / (24 * 60)) * 100
+                            const hour = Number.parseInt(time.split(":")[0]);
+                            const minute = Number.parseInt(time.split(":")[1]);
+                            const position =
+                              ((hour * 60 + minute) / (24 * 60)) * 100;
 
                             return (
                               <div
@@ -115,15 +127,16 @@ export default function TabWater() {
                                   <div className="h-16 border-l border-dashed border-blue-400 mt-1"></div>
                                 </div>
                               </div>
-                            )
+                            );
                           })}
 
                         {/* Low Tide Markers */}
                         {info.lowTide.map((time, i) => {
                           // Calculate position based on time (simplified)
-                          const hour = Number.parseInt(time.split(":")[0])
-                          const minute = Number.parseInt(time.split(":")[1])
-                          const position = ((hour * 60 + minute) / (24 * 60)) * 100
+                          const hour = Number.parseInt(time.split(":")[0]);
+                          const minute = Number.parseInt(time.split(":")[1]);
+                          const position =
+                            ((hour * 60 + minute) / (24 * 60)) * 100;
 
                           return (
                             <div
@@ -137,7 +150,7 @@ export default function TabWater() {
                                 <span>{time}</span>
                               </div>
                             </div>
-                          )
+                          );
                         })}
                       </div>
                     </div>
@@ -178,7 +191,9 @@ export default function TabWater() {
               variant="outline"
               size="icon"
               className="rounded-full cursor-pointer bg-white shadow-md h-10 w-10"
-              onClick={() => setCurrentTideIndex(Math.max(0, currentTideIndex - 1))}
+              onClick={() =>
+                setCurrentTideIndex(Math.max(0, currentTideIndex - 1))
+              }
               disabled={currentTideIndex === 0}
             >
               <ChevronLeft className="h-5 w-5" />
@@ -187,7 +202,11 @@ export default function TabWater() {
               variant="outline"
               size="icon"
               className="rounded-full cursor-pointer bg-white shadow-md h-10 w-10"
-              onClick={() => setCurrentTideIndex(Math.min(tideInfo.length - 1, currentTideIndex + 1))}
+              onClick={() =>
+                setCurrentTideIndex(
+                  Math.min(tideInfo.length - 1, currentTideIndex + 1)
+                )
+              }
               disabled={currentTideIndex === tideInfo.length - 1}
             >
               <ChevronRight className="h-5 w-5" />
@@ -213,11 +232,12 @@ export default function TabWater() {
             <Droplets className="h-5 w-5 mr-2" /> 물때 팁
           </h4>
           <p className="mt-2 text-blue-800">
-            참돔과 감성돔은 주로 간조에서 만조로 바뀌는 창조류 때 활발하게 활동합니다. 특히 해 뜨기 직전과
-            해 질 무렵의 창조류 시간대가 가장 조황이 좋습니다.
+            참돔과 감성돔은 주로 간조에서 만조로 바뀌는 창조류 때 활발하게
+            활동합니다. 특히 해 뜨기 직전과 해 질 무렵의 창조류 시간대가 가장
+            조황이 좋습니다.
           </p>
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/app/boat-reservation/[id]/page.tsx
+++ b/src/app/boat-reservation/[id]/page.tsx
@@ -1,14 +1,8 @@
-"use client"
-
-import type React from "react"
-
-import Link from "next/link"
-import {
-  ChevronLeft,
-  Star,
-} from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type React from "react";
+import Link from "next/link";
+import { ChevronLeft, Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import PlaceInfo from "@/app/boat-reservation/[id]/components/PlaceInfo";
 import PhoneInfo from "@/app/boat-reservation/[id]/components/PhoneInfo";
 import ReservationInfo from "@/app/boat-reservation/[id]/components/ReservationInfo";
@@ -17,21 +11,39 @@ import TabFish from "@/app/boat-reservation/[id]/components/TabFish";
 import TabWater from "@/app/boat-reservation/[id]/components/TabWater";
 import ReviewCard from "@/components/ReviewCard";
 import ImageGallery from "@/app/boat-reservation/[id]/components/ImageGallery";
+import { PostDetailType } from "@/types/boatPostType";
 
-export default function BoatReservationDetail() {
+async function getBoatPostDetail(id: string): Promise<PostDetailType> {
+  const response = await fetch(`http://localhost:3000/api/boatPostMock/${id}`, {
+    cache: "no-store",
+  });
+  const data = await response.json();
+  return data;
+}
+
+export default async function BoatReservationDetail({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const boatPostDetail = await getBoatPostDetail(params.id);
+
   // 리뷰 데이터
   const reviews = [
     {
-      id : 'a',
+      id: "a",
       user: "바다사랑",
       date: "2023.10.15",
       rating: 5,
       content:
         "정말 좋은 경험이었습니다. 선장님이 친절하시고 물고기도 많이 잡았어요. 특히 참돔 대물을 낚아서 기분이 좋았습니다. 다음에도 꼭 이용할 예정입니다.",
-      images: ["/placeholder.svg?height=100&width=100", "/placeholder.svg?height=100&width=100"],
+      images: [
+        "/placeholder.svg?height=100&width=100",
+        "/placeholder.svg?height=100&width=100",
+      ],
     },
     {
-      id : 'b',
+      id: "b",
       user: "낚시초보",
       date: "2023.10.08",
       rating: 4,
@@ -40,7 +52,7 @@ export default function BoatReservationDetail() {
       images: [],
     },
     {
-      id : 'c',
+      id: "c",
       user: "물고기헌터",
       date: "2023.09.25",
       rating: 5,
@@ -48,18 +60,21 @@ export default function BoatReservationDetail() {
         "여러 선상 낚시를 다녀봤지만 이곳이 가장 좋았습니다. 시설도 깨끗하고 물고기도 많이 잡혔어요. 특히 도시락이 맛있었습니다!",
       images: ["/placeholder.svg?height=100&width=100"],
     },
-  ]
+  ];
   return (
     <div className="min-h-screen">
       <div className="max-w-[1280px] mx-auto py-8 px-4 sm:px-6 lg:px-8">
         <div className="mb-6">
-          <Link href="/boat-reservation" className="text-cyan-600 hover:text-cyan-800 flex items-center">
+          <Link
+            href="/boat-reservation"
+            className="text-cyan-600 hover:text-cyan-800 flex items-center"
+          >
             <ChevronLeft className="h-4 w-4 mr-1" /> 목록으로 돌아가기
           </Link>
         </div>
 
         <div className="mb-6 font-bold text-4xl">
-          즐거운 선상 낚시
+          {boatPostDetail.data.detailShipFishingPost.subject}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -70,12 +85,23 @@ export default function BoatReservationDetail() {
             {/* 상세 정보 탭 */}
             <Tabs defaultValue="info" className="w-full">
               <TabsList className="grid w-full grid-cols-3">
-                <TabsTrigger value="info" className="cursor-pointer">상세 정보</TabsTrigger>
-                <TabsTrigger value="fish" className="cursor-pointer">어종 정보</TabsTrigger>
-                <TabsTrigger value="tide" className="cursor-pointer">물때 정보</TabsTrigger>
+                <TabsTrigger value="info" className="cursor-pointer">
+                  상세 정보
+                </TabsTrigger>
+                <TabsTrigger value="fish" className="cursor-pointer">
+                  어종 정보
+                </TabsTrigger>
+                <TabsTrigger value="tide" className="cursor-pointer">
+                  물때 정보
+                </TabsTrigger>
               </TabsList>
               <TabsContent value="info" className="mt-6">
-                <TabDetail />
+                <TabDetail
+                  detailShipFishingPost={
+                    boatPostDetail.data.detailShipFishingPost
+                  }
+                  detailShip={boatPostDetail.data.detailShip}
+                />
               </TabsContent>
               <TabsContent value="fish" className="mt-6">
                 <TabFish />
@@ -91,8 +117,12 @@ export default function BoatReservationDetail() {
                 <h2 className="text-2xl font-bold">리뷰 및 평점</h2>
                 <div className="flex items-center bg-sub-2 text-gray-30 px-3 py-1 rounded-full">
                   <Star className="h-5 w-5 fill-amber-400 text-amber-400 mr-1" />
-                  <span className="font-semibold">3.8</span>
-                  <span className="text-sm font-medium text-gray-500 ml-1">({reviews.length})</span>
+                  <span className="font-semibold">
+                    {boatPostDetail.data.detailShipFishingPost.reviewEverRate}
+                  </span>
+                  <span className="text-sm font-medium text-gray-500 ml-1">
+                    ({reviews.length})
+                  </span>
                 </div>
               </div>
 
@@ -118,14 +148,18 @@ export default function BoatReservationDetail() {
 
           {/* 예약 관련 정보 */}
           <div className="lg:col-span-1">
-            <div className="sticky top-8 space-y-6">
-              <ReservationInfo/>
-              <PhoneInfo/>
-              <PlaceInfo/>
+            <div className="sticky top-[100px] space-y-6">
+              <ReservationInfo
+                detailShipFishingPost={
+                  boatPostDetail.data.detailShipFishingPost
+                }
+              />
+              <PhoneInfo />
+              <PlaceInfo />
             </div>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/boat-reservation/loading.tsx
+++ b/src/app/boat-reservation/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <p>🚤 낚싯배 정보를 불러오는 중입니다...</p>
+    </div>
+  );
+}

--- a/src/app/boat-reservation/page.tsx
+++ b/src/app/boat-reservation/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Select,
   SelectContent,
@@ -10,102 +8,29 @@ import {
 import BoatCard from "@/components/BoatCard";
 import SearchBox from "@/app/boat-reservation/components/SearchBox";
 import FilterBox from "@/app/boat-reservation/components/FilterBox";
-import { useEffect, useState } from "react";
 import { PostType } from "@/types/boatPostType";
 
-// 더미 데이터
-const dummyBoats: PostType[] = [
-  {
-    subject: "빵빵이호 낚시 투어",
-    price: 80000,
-    location: "부산 기장군",
-    startTime: "15:00",
-    endTime: "17:30",
-    durationTime: "02:30",
-    shipFishingPostId: 1,
-    imageList: [
-      "/placeholder.svg?height=200&width=300",
-      "/placeholder.svg?height=200&width=300",
-    ],
-    fishList: [1, 2, 3],
-    reviewEverRate: 5.0,
-    reviewCount: 31,
-  },
-  {
-    subject: "옥지호 바다 낚시",
-    price: 120000,
-    location: "제주 서귀포시",
-    startTime: "09:00",
-    endTime: "12:00",
-    durationTime: "03:00",
-    shipFishingPostId: 2,
-    imageList: [
-      "/placeholder.svg?height=200&width=300",
-      "/placeholder.svg?height=200&width=300",
-    ],
-    fishList: [2, 4, 5],
-    reviewEverRate: 4.0,
-    reviewCount: 36,
-  },
-  {
-    subject: "김노엠호 낚시 투어",
-    price: 60000,
-    location: "인천 옹진군",
-    startTime: "13:00",
-    endTime: "16:00",
-    durationTime: "03:00",
-    shipFishingPostId: 3,
-    imageList: [
-      "/placeholder.svg?height=200&width=300",
-      "/placeholder.svg?height=200&width=300",
-    ],
-    fishList: [1, 3, 6],
-    reviewEverRate: 4.5,
-    reviewCount: 14,
-  },
-  {
-    subject: "제갈제니호 낚시",
-    price: 100000,
-    location: "강원 속초시",
-    startTime: "10:00",
-    endTime: "14:00",
-    durationTime: "04:00",
-    shipFishingPostId: 4,
-    imageList: [
-      "/placeholder.svg?height=200&width=300",
-      "/placeholder.svg?height=200&width=300",
-    ],
-    fishList: [2, 5, 7],
-    reviewEverRate: 2.5,
-    reviewCount: 32,
-  },
-];
-
 // 더미 API 함수
-const fetchBoats = async (): Promise<PostType[]> => {
-  // 실제 API 호출처럼 지연 시간 추가
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  return dummyBoats;
-};
+async function getBoatPosts(): Promise<PostType[]> {
+  try {
+    const response = await fetch("http://localhost:3000/api/boatPostMock", {
+      cache: "no-store",
+    });
 
-export default function BoatReservation() {
-  const [boats, setBoats] = useState<PostType[]>([]);
-  const [loading, setLoading] = useState(true);
+    if (!response.ok) {
+      throw new Error("데이터를 불러오는데 실패했습니다");
+    }
 
-  useEffect(() => {
-    const loadBoats = async () => {
-      try {
-        const data = await fetchBoats();
-        setBoats(data);
-      } catch (err) {
-        console.error("선박 정보를 불러오는데 실패했습니다.", err);
-      } finally {
-        setLoading(false);
-      }
-    };
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("API 호출 에러:", error);
+    return []; // 에러 시 빈 배열 반환
+  }
+}
 
-    loadBoats();
-  }, []);
+export default async function BoatReservation() {
+  const boatPostsData = await getBoatPosts();
 
   return (
     <div className="min-h-screen">
@@ -124,7 +49,9 @@ export default function BoatReservation() {
           <FilterBox />
           <div className="lg:col-span-3 space-y-6">
             <div className="flex justify-between items-center">
-              <h2 className="text-xl font-bold">검색 결과 ({boats.length})</h2>
+              <h2 className="text-xl font-bold">
+                검색 결과 ({boatPostsData.length})
+              </h2>
               <Select defaultValue="recommended">
                 <SelectTrigger className="w-[180px] cursor-pointer">
                   <SelectValue placeholder="정렬 기준" />
@@ -138,15 +65,11 @@ export default function BoatReservation() {
               </Select>
             </div>
 
-            {loading ? (
-              <div className="text-center py-8">로딩 중...</div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {boats.map((boat) => (
-                  <BoatCard key={boat.shipFishingPostId} boatData={boat} />
-                ))}
-              </div>
-            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {boatPostsData.map((boat) => (
+                <BoatCard key={boat.shipFishingPostId} boatData={boat} />
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/boat-reservation/page.tsx
+++ b/src/app/boat-reservation/page.tsx
@@ -1,25 +1,130 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import BoatCard from "@/components/BoatCard";
 import SearchBox from "@/app/boat-reservation/components/SearchBox";
 import FilterBox from "@/app/boat-reservation/components/FilterBox";
+import { useEffect, useState } from "react";
+import { PostType } from "@/types/boatPostType";
+
+// 더미 데이터
+const dummyBoats: PostType[] = [
+  {
+    subject: "빵빵이호 낚시 투어",
+    price: 80000,
+    location: "부산 기장군",
+    startTime: "15:00",
+    endTime: "17:30",
+    durationTime: "02:30",
+    shipFishingPostId: 1,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [1, 2, 3],
+    reviewEverRate: 5.0,
+    reviewCount: 31,
+  },
+  {
+    subject: "옥지호 바다 낚시",
+    price: 120000,
+    location: "제주 서귀포시",
+    startTime: "09:00",
+    endTime: "12:00",
+    durationTime: "03:00",
+    shipFishingPostId: 2,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [2, 4, 5],
+    reviewEverRate: 4.0,
+    reviewCount: 36,
+  },
+  {
+    subject: "김노엠호 낚시 투어",
+    price: 60000,
+    location: "인천 옹진군",
+    startTime: "13:00",
+    endTime: "16:00",
+    durationTime: "03:00",
+    shipFishingPostId: 3,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [1, 3, 6],
+    reviewEverRate: 4.5,
+    reviewCount: 14,
+  },
+  {
+    subject: "제갈제니호 낚시",
+    price: 100000,
+    location: "강원 속초시",
+    startTime: "10:00",
+    endTime: "14:00",
+    durationTime: "04:00",
+    shipFishingPostId: 4,
+    imageList: [
+      "/placeholder.svg?height=200&width=300",
+      "/placeholder.svg?height=200&width=300",
+    ],
+    fishList: [2, 5, 7],
+    reviewEverRate: 2.5,
+    reviewCount: 32,
+  },
+];
+
+// 더미 API 함수
+const fetchBoats = async (): Promise<PostType[]> => {
+  // 실제 API 호출처럼 지연 시간 추가
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return dummyBoats;
+};
 
 export default function BoatReservation() {
+  const [boats, setBoats] = useState<PostType[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadBoats = async () => {
+      try {
+        const data = await fetchBoats();
+        setBoats(data);
+      } catch (err) {
+        console.error("선박 정보를 불러오는데 실패했습니다.", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadBoats();
+  }, []);
+
   return (
     <div className="min-h-screen">
       <div className="bg-sky-700 text-white py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <h1 className="text-3xl font-bold mb-4">선상 낚시 예약</h1>
-          <p className="text-lg text-cyan-100 max-w-3xl">전국 각지의 선상 낚시를 검색하고 예약해보세요!</p>
+          <p className="text-lg text-cyan-100 max-w-3xl">
+            전국 각지의 선상 낚시를 검색하고 예약해보세요!
+          </p>
         </div>
       </div>
 
       <div className="max-w-[1280px] mx-auto py-8 px-4 sm:px-6 lg:px-8">
-        <SearchBox/>
+        <SearchBox />
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-          <FilterBox/>
+          <FilterBox />
           <div className="lg:col-span-3 space-y-6">
             <div className="flex justify-between items-center">
-              <h2 className="text-xl font-bold">검색 결과 (24)</h2>
+              <h2 className="text-xl font-bold">검색 결과 ({boats.length})</h2>
               <Select defaultValue="recommended">
                 <SelectTrigger className="w-[180px] cursor-pointer">
                   <SelectValue placeholder="정렬 기준" />
@@ -33,51 +138,18 @@ export default function BoatReservation() {
               </Select>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <BoatCard
-                id="0"
-                image="/placeholder.svg?height=200&width=300"
-                name="해양호"
-                location="부산 기장군"
-                rating={4.8}
-                reviews={124}
-                price={80000}
-                fishTypes={["참돔", "감성돔", "농어"]}
-              />
-              <BoatCard
-                id="0"
-                image="/placeholder.svg?height=200&width=300"
-                name="블루오션호"
-                location="강원 속초시"
-                rating={4.5}
-                reviews={98}
-                price={70000}
-                fishTypes={["가자미", "방어", "대구"]}
-              />
-              <BoatCard
-                id="2"
-                image="/placeholder.svg?height=200&width=300"
-                name="황금어장호"
-                location="인천 옹진군"
-                rating={4.3}
-                reviews={56}
-                price={65000}
-                fishTypes={["우럭", "광어", "놀래미"]}
-              />
-              <BoatCard
-                id="1"
-                image="/placeholder.svg?height=200&width=300"
-                name="제주바다호"
-                location="제주 서귀포시"
-                rating={4.7}
-                reviews={112}
-                price={90000}
-                fishTypes={["다금바리", "참돔", "방어"]}
-              />
-            </div>
+            {loading ? (
+              <div className="text-center py-8">로딩 중...</div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {boats.map((boat) => (
+                  <BoatCard key={boat.shipFishingPostId} boatData={boat} />
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/fishing-registration/page.tsx
+++ b/src/app/fishing-registration/page.tsx
@@ -22,65 +22,156 @@ const halfHourOptions = Array.from({ length: 48 }, (_, i) => {
   return `${hour}:${minute}`;
 });
 
+// 폼 데이터 타입 정의
+type FishingRegistrationForm = {
+  title: string;
+  price: number;
+  startTime: string;
+  endTime: string;
+  maxPeople: number;
+  selectedShip: string;
+  departureRegion: string;
+  content: string;
+  selectedFiles: File[];
+  previewUrls: string[];
+  unavailableDates: Date[];
+  selectedFishSpecies: string[];
+};
+
+// 유효성 검사 오류 타입 정의
+type ValidationErrors = {
+  [key in keyof FishingRegistrationForm]?: boolean;
+};
+
 export default function Page() {
-  const [title, setTitle] = useState("");
-  const [price, setPrice] = useState<number>(0);
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
-  const [maxPeople, setMaxPeople] = useState(2);
-  const [selectedShip, setSelectedShip] = useState("");
-  const [departureRegion, setDepartureRegion] = useState("");
-  const [content, setContent] = useState("");
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
-  const [unavailableDates, setUnavailableDates] = useState<Date[]>([]);
-  const [selectedFishSpecies, setSelectedFishSpecies] = useState<string[]>([]);
+  const [formData, setFormData] = useState<FishingRegistrationForm>({
+    title: "",
+    price: 0,
+    startTime: "",
+    endTime: "",
+    maxPeople: 2,
+    selectedShip: "",
+    departureRegion: "",
+    content: "",
+    selectedFiles: [],
+    previewUrls: [],
+    unavailableDates: [],
+    selectedFishSpecies: [],
+  });
+
+  // 유효성 검사 오류 상태 추가
+  const [errors, setErrors] = useState<ValidationErrors>({});
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 상태 업데이트 함수
+  const updateFormData = (
+    field: keyof FishingRegistrationForm,
+    value: FishingRegistrationForm[keyof FishingRegistrationForm]
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+
+    // 입력 시 해당 필드의 오류 상태를 초기화
+    if (errors[field]) {
+      setErrors((prev) => ({
+        ...prev,
+        [field]: false,
+      }));
+    }
+  };
+
+  // 유효성 검사 함수
+  const validateForm = (): boolean => {
+    const newErrors: ValidationErrors = {};
+
+    // 필수 필드 검사
+    if (!formData.title.trim()) newErrors.title = true;
+    if (formData.price <= 0) newErrors.price = true;
+    if (!formData.startTime) newErrors.startTime = true;
+    if (!formData.endTime) newErrors.endTime = true;
+    if (!formData.selectedShip) newErrors.selectedShip = true;
+    if (!formData.departureRegion.trim()) newErrors.departureRegion = true;
+    if (!formData.content.trim()) newErrors.content = true;
+    if (formData.selectedFiles.length === 0) newErrors.selectedFiles = true;
+    if (formData.selectedFishSpecies.length === 0)
+      newErrors.selectedFishSpecies = true;
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
     const newFiles = Array.from(files);
-    const currentCount = selectedFiles.length;
+    const currentCount = formData.selectedFiles.length;
     const totalCount = currentCount + newFiles.length;
+
     if (totalCount > 10) {
       const allowedCount = 10 - currentCount;
       alert("최대 10장까지 업로드 가능합니다.");
       newFiles.splice(allowedCount);
     }
-    const updatedFiles = [...selectedFiles, ...newFiles];
-    setSelectedFiles(updatedFiles);
+
+    const updatedFiles = [...formData.selectedFiles, ...newFiles];
     const urls = updatedFiles.map((file) => URL.createObjectURL(file));
-    setPreviewUrls(urls);
+
+    updateFormData("selectedFiles", updatedFiles);
+    updateFormData("previewUrls", urls);
   };
 
   const removeImage = (index: number) => {
-    const updatedFiles = selectedFiles.filter((_, i) => i !== index);
-    setSelectedFiles(updatedFiles);
+    const updatedFiles = formData.selectedFiles.filter((_, i) => i !== index);
     const updatedUrls = updatedFiles.map((file) => URL.createObjectURL(file));
-    setPreviewUrls(updatedUrls);
-  };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    alert("예약 게시글이 등록되었습니다.");
+    updateFormData("selectedFiles", updatedFiles);
+    updateFormData("previewUrls", updatedUrls);
   };
 
   const removeDate = (idx: number) => {
-    setUnavailableDates((prev) => prev.filter((_, i) => i !== idx));
+    const updatedDates = formData.unavailableDates.filter((_, i) => i !== idx);
+    updateFormData("unavailableDates", updatedDates);
   };
 
   const handleFishSelect = (value: string) => {
-    if (!selectedFishSpecies.includes(value)) {
-      setSelectedFishSpecies((prev) => [...prev, value]);
+    if (!formData.selectedFishSpecies.includes(value)) {
+      updateFormData("selectedFishSpecies", [
+        ...formData.selectedFishSpecies,
+        value,
+      ]);
     }
   };
 
   const removeFishSpecies = (value: string) => {
-    setSelectedFishSpecies((prev) =>
-      prev.filter((species) => species !== value)
+    const updatedSpecies = formData.selectedFishSpecies.filter(
+      (species) => species !== value
     );
+    updateFormData("selectedFishSpecies", updatedSpecies);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // 유효성 검사 실행
+    if (!validateForm()) {
+      alert("모든 필수 항목을 입력해주세요.");
+      return;
+    }
+
+    const response = await fetch("http://localhost:3000/api/boatPostMock", {
+      method: "POST",
+      body: JSON.stringify(formData),
+    });
+
+    if (response.ok) {
+      console.log(response);
+      alert("예약 게시글이 등록되었습니다.");
+    } else {
+      alert("예약 게시글 등록에 실패했습니다.");
+    }
   };
 
   return (
@@ -119,10 +210,15 @@ export default function Page() {
               <Input
                 id="title"
                 placeholder="게시글 제목을 입력해주세요"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="placeholder:text-base"
+                value={formData.title}
+                onChange={(e) => updateFormData("title", e.target.value)}
+                className={`placeholder:text-base ${
+                  errors.title ? "border-red-500" : ""
+                }`}
               />
+              {errors.title && (
+                <p className="text-red-500 text-sm mt-1">제목을 입력해주세요</p>
+              )}
             </div>
             {/* 가격 */}
             <div>
@@ -136,50 +232,99 @@ export default function Page() {
                 id="price"
                 type="number"
                 placeholder="예: 50000"
-                value={price === 0 ? "" : price}
-                onChange={(e) => setPrice(Number(e.target.value))}
-                className="placeholder:text-base"
+                value={formData.price === 0 ? "" : formData.price}
+                onChange={(e) =>
+                  updateFormData("price", Number(e.target.value))
+                }
+                className={`placeholder:text-base ${
+                  errors.price ? "border-red-500" : ""
+                }`}
               />
+              {errors.price && (
+                <p className="text-red-500 text-sm mt-1">가격을 입력해주세요</p>
+              )}
             </div>
             {/* 총 소요 시간 */}
             <div className="col-span-2">
               <label className="block mb-2 text-base font-medium text-gray-700">
                 총 소요 시간
               </label>
-              <div className="flex items-center gap-3">
-                <Select value={startTime} onValueChange={setStartTime}>
-                  <SelectTrigger className="w-full cursor-pointer">
-                    <SelectValue
-                      placeholder="시작 시간"
-                      className="placeholder:text-base"
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {halfHourOptions.map((time) => (
-                      <SelectItem key={time} value={time}>
-                        {time}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <span className="text-gray-700">~</span>
-                <Select value={endTime} onValueChange={setEndTime}>
-                  <SelectTrigger className="w-full cursor-pointer">
-                    <SelectValue
-                      placeholder="종료 시간"
-                      className="placeholder:text-base"
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {halfHourOptions
-                      .filter((time) => (startTime ? time > startTime : true))
-                      .map((time) => (
+              <div className="flex items-center gap-3 justify-between">
+                <div className="flex flex-col gap-2 w-[48%]">
+                  <Select
+                    value={formData.startTime}
+                    onValueChange={(value) =>
+                      updateFormData("startTime", value)
+                    }
+                  >
+                    <SelectTrigger
+                      className={`w-full cursor-pointer ${
+                        errors.startTime ? "border-red-500" : ""
+                      }`}
+                    >
+                      <SelectValue
+                        placeholder="시작 시간"
+                        className="placeholder:text-base"
+                      />
+                    </SelectTrigger>
+                    <SelectContent
+                      side="bottom"
+                      sideOffset={4}
+                      align="start"
+                      avoidCollisions={false}
+                    >
+                      {halfHourOptions.map((time) => (
                         <SelectItem key={time} value={time}>
                           {time}
                         </SelectItem>
                       ))}
-                  </SelectContent>
-                </Select>
+                    </SelectContent>
+                  </Select>
+                  {errors.startTime && (
+                    <p className="text-red-500 text-sm mt-1">
+                      시작 시간을 선택해주세요
+                    </p>
+                  )}
+                </div>
+                <span className="text-gray-700">~</span>
+                <div className="flex flex-col gap-2 w-[48%]">
+                  <Select
+                    value={formData.endTime}
+                    onValueChange={(value) => updateFormData("endTime", value)}
+                  >
+                    <SelectTrigger
+                      className={`w-full cursor-pointer ${
+                        errors.endTime ? "border-red-500" : ""
+                      }`}
+                    >
+                      <SelectValue
+                        placeholder="종료 시간"
+                        className="placeholder:text-base"
+                      />
+                    </SelectTrigger>
+                    <SelectContent
+                      side="bottom"
+                      sideOffset={4}
+                      align="start"
+                      avoidCollisions={false}
+                    >
+                      {halfHourOptions
+                        .filter((time) =>
+                          formData.startTime ? time > formData.startTime : true
+                        )
+                        .map((time) => (
+                          <SelectItem key={time} value={time}>
+                            {time}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  {errors.endTime && (
+                    <p className="text-red-500 text-sm mt-1">
+                      종료 시간을 선택해주세요
+                    </p>
+                  )}
+                </div>
               </div>
             </div>
             {/* 최대 인원 */}
@@ -192,16 +337,23 @@ export default function Page() {
                   type="button"
                   variant="outline"
                   className="cursor-pointer"
-                  onClick={() => setMaxPeople(Math.max(1, maxPeople - 1))}
+                  onClick={() =>
+                    updateFormData(
+                      "maxPeople",
+                      Math.max(1, formData.maxPeople - 1)
+                    )
+                  }
                 >
                   -
                 </Button>
-                <span className="text-lg">{maxPeople}</span>
+                <span className="text-lg">{formData.maxPeople}</span>
                 <Button
                   type="button"
                   variant="outline"
                   className="cursor-pointer"
-                  onClick={() => setMaxPeople(maxPeople + 1)}
+                  onClick={() =>
+                    updateFormData("maxPeople", formData.maxPeople + 1)
+                  }
                 >
                   +
                 </Button>
@@ -212,8 +364,15 @@ export default function Page() {
               <label className="block mb-2 text-base font-medium text-gray-700">
                 선박 선택
               </label>
-              <Select value={selectedShip} onValueChange={setSelectedShip}>
-                <SelectTrigger className="w-full cursor-pointer">
+              <Select
+                value={formData.selectedShip}
+                onValueChange={(value) => updateFormData("selectedShip", value)}
+              >
+                <SelectTrigger
+                  className={`w-full cursor-pointer ${
+                    errors.selectedShip ? "border-red-500" : ""
+                  }`}
+                >
                   <SelectValue
                     placeholder="선박을 선택하세요"
                     className="placeholder:text-base"
@@ -225,6 +384,9 @@ export default function Page() {
                   <SelectItem value="ship3">선박 3</SelectItem>
                 </SelectContent>
               </Select>
+              {errors.selectedShip && (
+                <p className="text-red-500 text-sm mt-1">선박을 선택해주세요</p>
+              )}
             </div>
             {/* 출항지역 */}
             <div>
@@ -237,10 +399,19 @@ export default function Page() {
               <Input
                 id="departureRegion"
                 placeholder="출항지역을 입력해주세요"
-                value={departureRegion}
-                onChange={(e) => setDepartureRegion(e.target.value)}
-                className="placeholder:text-base"
+                value={formData.departureRegion}
+                onChange={(e) =>
+                  updateFormData("departureRegion", e.target.value)
+                }
+                className={`placeholder:text-base ${
+                  errors.departureRegion ? "border-red-500" : ""
+                }`}
               />
+              {errors.departureRegion && (
+                <p className="text-red-500 text-sm mt-1">
+                  출항지역을 입력해주세요
+                </p>
+              )}
             </div>
           </div>
         </section>
@@ -260,10 +431,15 @@ export default function Page() {
             <Textarea
               id="content"
               placeholder="서비스 이용 전 준비물, 교통편, 할인 정보 등 상세한 내용을 입력해주세요."
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              className="min-h-[200px] placeholder:text-base"
+              value={formData.content}
+              onChange={(e) => updateFormData("content", e.target.value)}
+              className={`min-h-[200px] placeholder:text-base ${
+                errors.content ? "border-red-500" : ""
+              }`}
             />
+            {errors.content && (
+              <p className="text-red-500 text-sm mt-1">내용을 입력해주세요</p>
+            )}
           </div>
         </section>
 
@@ -288,15 +464,22 @@ export default function Page() {
             <Button
               type="button"
               variant="outline"
-              className="mt-4 cursor-pointer"
+              className={`mt-4 cursor-pointer ${
+                errors.selectedFiles ? "border-red-500" : ""
+              }`}
               onClick={() => fileInputRef.current?.click()}
             >
               파일 선택
             </Button>
+            {errors.selectedFiles && (
+              <p className="text-red-500 text-sm mt-1">
+                이미지를 업로드해주세요
+              </p>
+            )}
           </div>
-          {previewUrls.length > 0 && (
+          {formData.previewUrls.length > 0 && (
             <div className="mt-4 flex gap-4 overflow-x-auto">
-              {previewUrls.map((url, index) => (
+              {formData.previewUrls.map((url, index) => (
                 <div
                   key={index}
                   className="relative w-32 h-32 flex-shrink-0 rounded-lg overflow-hidden shadow-lg"
@@ -325,24 +508,45 @@ export default function Page() {
           </h2>
           <div className="mb-4">
             <Select value="" onValueChange={handleFishSelect}>
-              <SelectTrigger className="w-full cursor-pointer">
+              <SelectTrigger
+                className={`w-full cursor-pointer ${
+                  errors.selectedFishSpecies ? "border-red-500" : ""
+                }`}
+              >
                 <SelectValue
                   placeholder="어종 선택"
                   className="placeholder:text-base"
                 />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="고등어">고등어</SelectItem>
-                <SelectItem value="참치">참치</SelectItem>
-                <SelectItem value="연어">연어</SelectItem>
-                <SelectItem value="광어">광어</SelectItem>
+              <SelectContent
+                side="bottom"
+                sideOffset={4}
+                align="start"
+                avoidCollisions={false}
+              >
+                <SelectItem value="갑오징어">갑오징어</SelectItem>
+                <SelectItem value="문어">문어</SelectItem>
+                <SelectItem value="삼치">삼치</SelectItem>
                 <SelectItem value="우럭">우럭</SelectItem>
+                <SelectItem value="농어">농어</SelectItem>
+                <SelectItem value="참돔">참돔</SelectItem>
+                <SelectItem value="광어">광어</SelectItem>
+                <SelectItem value="대구">대구</SelectItem>
+                <SelectItem value="방어">방어</SelectItem>
+                <SelectItem value="가자미">가자미</SelectItem>
+                <SelectItem value="민어">민어</SelectItem>
+                <SelectItem value="전갱이">전갱이</SelectItem>
+                <SelectItem value="백조기">백조기</SelectItem>
+                <SelectItem value="쭈꾸미">쭈꾸미</SelectItem>
               </SelectContent>
             </Select>
+            {errors.selectedFishSpecies && (
+              <p className="text-red-500 text-sm mt-1">어종을 선택해주세요</p>
+            )}
           </div>
-          {selectedFishSpecies.length > 0 && (
+          {formData.selectedFishSpecies.length > 0 && (
             <div className="flex flex-wrap gap-2">
-              {selectedFishSpecies.map((species) => (
+              {formData.selectedFishSpecies.map((species) => (
                 <div
                   key={species}
                   className="relative bg-green-100 text-green-800 px-4 py-2 rounded text-base"
@@ -368,20 +572,22 @@ export default function Page() {
             <div>
               <Calendar
                 mode="multiple"
-                selected={unavailableDates}
-                onSelect={setUnavailableDates}
+                selected={formData.unavailableDates}
+                onSelect={(days) =>
+                  updateFormData("unavailableDates", days || [])
+                }
                 className="w-full"
               />
             </div>
             <div>
               <p className="mb-2 text-gray-700 font-medium">선택된 날짜</p>
-              {unavailableDates.length === 0 ? (
+              {formData.unavailableDates.length === 0 ? (
                 <p className="text-gray-500 text-base">
                   선택된 날짜가 없습니다.
                 </p>
               ) : (
                 <div className="flex flex-wrap gap-2">
-                  {unavailableDates.map((date, idx) => (
+                  {formData.unavailableDates.map((date, idx) => (
                     <div
                       key={idx}
                       className="relative bg-blue-100 text-blue-800 px-3 py-2 rounded text-base"

--- a/src/components/BoatCard.tsx
+++ b/src/components/BoatCard.tsx
@@ -1,34 +1,27 @@
-import { MapPin, Star, Heart } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import Link from "next/link"
+import { MapPin, Star, Heart } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import Link from "next/link";
 import Image from "next/image";
+import { PostType } from "@/types/boatPostType";
 
-export default function BoatCard({
-  id,
-  image,
-  name,
-  location,
-  rating,
-  reviews,
-  price,
-  fishTypes,
-}: {
-  id: string
-  image: string
-  name: string
-  location: string
-  rating: number
-  reviews: number
-  price: number
-  fishTypes: string[]
-}) {
+export default function BoatCard({ boatData }: { boatData: PostType }) {
   return (
     <Card className="overflow-hidden shadow-lg hover:shadow-xl transition-shadow pt-0">
       <div className="h-48 overflow-hidden">
         <Image
-          src={image || "/placeholder.svg"}
-          alt={name}
+          src={
+            boatData.imageList && boatData.imageList.length > 0
+              ? boatData.imageList[0]
+              : "/placeholder.svg"
+          }
+          alt={boatData.subject}
           className="w-full h-full object-cover"
           height={195}
           width={440}
@@ -38,24 +31,29 @@ export default function BoatCard({
         <div className="flex justify-between items-start">
           <div>
             <CardTitle className="text-xl flex gap-1.5 items-center">
-              {name}
-              <Heart className="text-red-500 cursor-pointer"/>
+              {boatData.subject}
+              <Heart className="text-red-500 cursor-pointer" />
             </CardTitle>
             <CardDescription className="flex items-center mt-1">
-              <MapPin className="h-4 w-4 mr-1" /> {location}
+              <MapPin className="h-4 w-4 mr-1" /> {boatData.location}
             </CardDescription>
           </div>
           <div className="flex items-center bg-cyan-50 text-gray-20 px-2 py-1 rounded">
             <Star className="h-4 w-4 fill-amber-400 text-amber-400 mr-1" />
-            <span className="font-medium">{rating}</span>
-            <span className="text-xs text-gray-500 ml-1">({reviews})</span>
+            <span className="font-medium">{boatData.reviewEverRate}</span>
+            <span className="text-xs text-gray-500 ml-1">
+              ({boatData.reviewCount})
+            </span>
           </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex flex-wrap gap-2">
-          {fishTypes.map((fish, index) => (
-            <span key={index} className="bg-gray-80 text-gray-800 text-xs px-2 py-1 rounded">
+          {boatData.fishList.map((fish, index) => (
+            <span
+              key={index}
+              className="bg-gray-80 text-gray-800 text-xs px-2 py-1 rounded"
+            >
               {fish}
             </span>
           ))}
@@ -63,13 +61,17 @@ export default function BoatCard({
         <div className="flex items-center justify-between">
           <div>
             <span className="text-sm text-gray-500">1인 기준</span>
-            <p className="text-xl font-bold text-primary-color">{price.toLocaleString()}원</p>
+            <p className="text-xl font-bold text-primary-color">
+              {boatData.price.toLocaleString()}원
+            </p>
           </div>
-          <Link href={`/boat-reservation/${id}`}>
-            <Button className="bg-primary hover:bg-sub-1 cursor-pointer">예약하기</Button>
+          <Link href={`/boat-reservation/${boatData.shipFishingPostId}`}>
+            <Button className="bg-primary hover:bg-sub-1 cursor-pointer">
+              예약하기
+            </Button>
           </Link>
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/src/components/BoatCard.tsx
+++ b/src/components/BoatCard.tsx
@@ -12,6 +12,11 @@ import Image from "next/image";
 import { PostType } from "@/types/boatPostType";
 
 export default function BoatCard({ boatData }: { boatData: PostType }) {
+  // 메인페이지에서 오류 발생
+  if (!boatData) {
+    return <div>데이터가 없습니다.</div>;
+  }
+
   return (
     <Card className="overflow-hidden shadow-lg hover:shadow-xl transition-shadow pt-0">
       <div className="h-48 overflow-hidden">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Header() {
   return (
-    <header className="w-full h-[90px] bg-[rgba(0,0,0,0.6)] backdrop-blur-[6px] flex items-center justify-between fixed top-0 left-0 right-0 z-9999999">
+    <header className="w-full h-[90px] bg-[rgba(0,0,0,0.6)] backdrop-blur-[6px] flex items-center justify-between fixed top-0 left-0 right-0 z-[9999]">
       <div className="w-[1280px] h-full mx-auto flex items-center justify-between">
         {/* 헤더 왼쪽 */}
         <div className="flex items-center justify-between">

--- a/src/types/boatPostType.ts
+++ b/src/types/boatPostType.ts
@@ -12,7 +12,7 @@ export interface PostType {
   reviewCount: number; // 추후에 추가 예정
 }
 
-export interface ShipFishingPost {
+export interface PostDetailPost {
   shipFishingPostId: number;
   subject: string;
   content: string;
@@ -24,7 +24,7 @@ export interface ShipFishingPost {
   reviewEverRate: number;
 }
 
-export interface Ship {
+export interface PostDetailShip {
   shipId: number;
   shipName: string;
   shipNumber: string;
@@ -39,19 +39,19 @@ export interface Ship {
   parkingAvailable: boolean;
 }
 
-export interface Member {
+export interface PostDetailMember {
   memberId: number;
   email: string;
   name: string;
   phone: string;
 }
 
-export interface ApiResponse {
+export interface PostDetailType {
   timestamp: string;
   data: {
-    detailShipFishingPost: ShipFishingPost;
-    detailShip: Ship;
-    detailMember: Member;
+    detailShipFishingPost: PostDetailPost;
+    detailShip: PostDetailShip;
+    detailMember: PostDetailMember;
   };
   success: boolean;
 }

--- a/src/types/boatPostType.ts
+++ b/src/types/boatPostType.ts
@@ -1,0 +1,57 @@
+export interface PostType {
+  shipFishingPostId: number; // 추후 shipFishPostId로 변경
+  subject: string;
+  location: string;
+  price: number;
+  startTime: string;
+  endTime: string;
+  durationTime: string;
+  imageList: string[] | null;
+  reviewEverRate: number;
+  fishList: number[]; // 추후에 추가 예정
+  reviewCount: number; // 추후에 추가 예정
+}
+
+export interface ShipFishingPost {
+  shipFishingPostId: number;
+  subject: string;
+  content: string;
+  price: number;
+  imageList: string[] | null;
+  startTime: string;
+  durationTime: string;
+  maxGuestCount: number;
+  reviewEverRate: number;
+}
+
+export interface Ship {
+  shipId: number;
+  shipName: string;
+  shipNumber: string;
+  departurePort: string;
+  publicRestroom: boolean;
+  loungeArea: boolean;
+  kitchenFacility: boolean;
+  fishingChair: boolean;
+  passengerInsurance: boolean;
+  fishingGearRental: boolean;
+  mealProvided: boolean;
+  parkingAvailable: boolean;
+}
+
+export interface Member {
+  memberId: number;
+  email: string;
+  name: string;
+  phone: string;
+}
+
+export interface ApiResponse {
+  timestamp: string;
+  data: {
+    detailShipFishingPost: ShipFishingPost;
+    detailShip: Ship;
+    detailMember: Member;
+  };
+  success: boolean;
+}


### PR DESCRIPTION
### 📦 데이터 및 타입 정의
- **더미 데이터 추가**
  - 선상낚시 게시글 테스트용 mock data 생성

- **타입 추가**
  - `Post`, `FishingPost`, `FishingDetailPost` 등 게시글 관련 타입 정의 및 확장

### 🔗 기능 구현
- **게시글 목록 연동**
  - 목서버에서 게시글 데이터 받아와 목록 화면에 렌더링

- **상세 페이지 API 및 연동**
  - 게시글 클릭 시 상세 페이지로 이동
  - 해당 게시글에 대한 상세 데이터를 API에서 받아서 출력

### ⏳ 로딩 처리
- **로딩 페이지 구현**
  - 게시글 목록 및 상세 페이지 데이터 로딩 시 로딩 컴포넌트 노출

### 개선해야 할 점
- 상세페이지 우측 aside가 너무 길어 잘리는 현상이 있습니다. 
- 백엔드 api의 누락된 데이터가 있었습니다.(어종 정보, 미출항 날짜, 최소 인원 등등)
- 이미지는 따로 추가하지 않았습니다.
- 필터 기능 구현 예정입니다.